### PR TITLE
fix: updated package-lock.json to reflect dependencies for deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1936,9 +1936,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
-      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "bn.js": {
       "version": "5.1.2",
@@ -2382,6 +2382,12 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
+    },
+    "chance": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.6.tgz",
+      "integrity": "sha512-DXLzaGjasDWbvlFAJyQBIwlzdQZuPdz4of9TTTxmHTjja88ZU/vBwUwxxjalSt43zWTPrhiJT0z0N4bZqfZS9w==",
+      "dev": true
     },
     "chardet": {
       "version": "0.7.0",
@@ -5267,6 +5273,12 @@
       "requires": {
         "globule": "^1.0.0"
       }
+    },
+    "generate-image": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/generate-image/-/generate-image-1.0.1.tgz",
+      "integrity": "sha512-j9dxDxqJA9OXI++CEZYGQ/yxgly4lVb1ac3vOdg3Rbq254ENVQvUV3Q4ukuRyP42CIXsPZ5tkshz8dPDxJca7w==",
+      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",


### PR DESCRIPTION
I used npm-merge-driver - npm 

to update the package-lock.json reflect the dependencies. Travis needs the updated version to pass test. 